### PR TITLE
更新模式 支持直接导出atlas大图 & 加了个随机生成开局的小程序

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -1,12 +1,12 @@
 {
-    "TTS_DE_MODE": true,
+    "GEN_MODE": "tts",
 
-    "data_dir": "your_project_dir/mad-roots/data",
+    "data_dir": "D:/MadRoots/Repository/mad-roots/data",
     "input_csv_filename": "cardInfo.csv",
     "initial_deck_setting": "initialDeck.txt",
     "cardback_file_name": "back.png",
-    "version": "v0.604",
+    "version": "v0.606",
     "ttf": "Chusung.ttf",
 
-    "output_dir": "your_project_dir/mad-roots/output"
+    "output_dir": "D:/MadRoots/Repository/mad-roots/output"
 }

--- a/config/config.json
+++ b/config/config.json
@@ -1,12 +1,12 @@
 {
     "GEN_MODE": "tts",
 
-    "data_dir": "D:/MadRoots/Repository/mad-roots/data",
+    "data_dir": "your_project_dir/Repository/mad-roots/data",
     "input_csv_filename": "cardInfo.csv",
     "initial_deck_setting": "initialDeck.txt",
     "cardback_file_name": "back.png",
     "version": "v0.606",
     "ttf": "Chusung.ttf",
 
-    "output_dir": "D:/MadRoots/Repository/mad-roots/output"
+    "output_dir": "your_project_dir/Repository/mad-roots/output"
 }

--- a/config/config.json
+++ b/config/config.json
@@ -1,12 +1,12 @@
 {
     "GEN_MODE": "tts",
 
-    "data_dir": "your_project_dir/Repository/mad-roots/data",
+    "data_dir": "your_project_dir/mad-roots/data",
     "input_csv_filename": "cardInfo.csv",
     "initial_deck_setting": "initialDeck.txt",
     "cardback_file_name": "back.png",
     "version": "v0.606",
     "ttf": "Chusung.ttf",
 
-    "output_dir": "your_project_dir/Repository/mad-roots/output"
+    "output_dir": "your_project_dir/mad-roots/output"
 }

--- a/src/RandomStartSetting.py
+++ b/src/RandomStartSetting.py
@@ -1,0 +1,32 @@
+import random
+
+def RandomStart(a, b, c):
+    # 创建一个空的7x7网格，外层包裹一圈"o"
+    grid = [['o' for i in range(7)] for j in range(7)]
+
+    # 放置A类道具
+    for i in range(a):
+        x, y = random.randint(1, 5), random.randint(1, 5)
+        while grid[x][y] != 'o':
+            x, y = random.randint(1, 5), random.randint(1, 5)
+        grid[x][y] = '+'
+
+    # 放置B类道具
+    for i in range(b):
+        x, y = random.randint(1, 5), random.randint(1, 5)
+        while grid[x][y] != 'o':
+            x, y = random.randint(1, 5), random.randint(1, 5)
+        grid[x][y] = '-'
+
+    # 放置C类道具
+    for i in range(c):
+        x, y = random.randint(1, 5), random.randint(1, 5)
+        while grid[x][y] != 'o':
+            x, y = random.randint(1, 5), random.randint(1, 5)
+        grid[x][y] = 'x'
+
+    # 打印结果
+    for row in grid:
+        print(' '.join(row))
+
+RandomStart(3,3,1)


### PR DESCRIPTION
TTS_DE_MODE弃用，改为参数GEN_MODE，目前有三种：
ttsde: 按照TTS Deck Builder的格式生成文件 每张卡只生成一张图片 例如有3张 105卡牌，则生成文件名是"03x card_105.png"
       TTS_DE_MODE 会在OUTPUT_DIR目录下自动生成三个文件夹：initialDeck, market和onBoard，分别对应了玩家初始套牌，市场牌和常驻牌
       这样的好处是导入进TTS之后会自动按照功能一摞一摞分好，不用再进行整理了。
tts: *推荐* 直接生成可以批量导入tts的图集，是若干张10*7的atlas大图，每张最多包含69张卡牌图片和1张卡背图片。
raw: 每一张卡牌生成一张图片，有3张105卡牌就会生成3个一样的文件 名为 "card_105_X.png"